### PR TITLE
Add Hook0 - French open-source webhooks-as-a-service

### DIFF
--- a/hook0.json
+++ b/hook0.json
@@ -32,7 +32,7 @@
       "logo_url": "https://www.hook0.com/mediakit/logo/400x400.png",
       "website_url": "https://www.hook0.com",
       "created_year": 2021,
-      "description": "Open-source webhooks-as-a-service (WaaS) platform built in Rust. Allows SaaS companies to provide webhooks to their users via a simple API, handling delivery in under 100ms, HMAC cryptographic signatures, configurable retry schedules, real-time monitoring, and subscriber management. Over 10 million webhooks delivered across 6 continents with 99.9% uptime SLA. GDPR compliant with EU data hosting. Available as managed cloud or self-hosted via Docker/Kubernetes. 100% bootstrapped, no VC funding.",
+      "description": "Open-source webhooks-as-a-service platform built in Rust. SaaS companies integrate it to send webhooks to their users. Handles delivery, HMAC signatures, retries, and monitoring. Available as managed cloud or self-hosted (Docker/Kubernetes). GDPR compliant, data hosted in France.",
       "category_list": ["Developer API"],
       "similar_solution_list": [
         {

--- a/hook0.json
+++ b/hook0.json
@@ -2,7 +2,7 @@
   "created": "2026-04-26",
   "title": "Hook0",
   "type": "Organisation",
-  "logo_url": "https://www.hook0.com/mediakit/logo/110x110-white.png",
+  "logo_url": "https://www.hook0.com/mediakit/logo/400x400.png",
   "location": {
     "title": "FGRIBREAU SARL",
     "address": "3 rue de l'Aubépine",
@@ -16,14 +16,23 @@
   "subsidiary_location_list": [],
   "website_url": "https://www.hook0.com",
   "founded_year": 2021,
-  "kpi_list": [],
+  "kpi_list": [
+    {
+      "year": 2024,
+      "staff": 2,
+      "earnings": "169500 EUR",
+      "total_assets": "",
+      "revenues": "",
+      "source_url": "https://www.societe.com/societe/fgribreau-850824350.html"
+    }
+  ],
   "solution_list": [
     {
       "title": "Hook0",
-      "logo_url": "https://www.hook0.com/mediakit/logo/110x110-white.png",
+      "logo_url": "https://www.hook0.com/mediakit/logo/400x400.png",
       "website_url": "https://www.hook0.com",
       "created_year": 2021,
-      "description": "Open-source webhooks-as-a-service (WaaS) platform. Allows SaaS companies to provide webhooks to their users via a simple API, handling delivery, HMAC signatures, automatic retries, monitoring, and subscriber management. Available as a managed cloud service or self-hosted.",
+      "description": "Open-source webhooks-as-a-service (WaaS) platform built in Rust. Allows SaaS companies to provide webhooks to their users via a simple API, handling delivery in under 100ms, HMAC cryptographic signatures, configurable retry schedules, real-time monitoring, and subscriber management. Over 10 million webhooks delivered across 6 continents with 99.9% uptime SLA. GDPR compliant with EU data hosting. Available as managed cloud or self-hosted via Docker/Kubernetes. 100% bootstrapped, no VC funding.",
       "category_list": ["Developer API"],
       "similar_solution_list": [
         {

--- a/hook0.json
+++ b/hook0.json
@@ -1,0 +1,88 @@
+{
+  "created": "2026-04-26",
+  "title": "Hook0",
+  "type": "Organisation",
+  "logo_url": "https://www.hook0.com/mediakit/logo/110x110-white.png",
+  "location": {
+    "title": "FGRIBREAU SARL",
+    "address": "3 rue de l'Aubépine",
+    "postal_code": "85110",
+    "city": "Chantonnay",
+    "country": "FR",
+    "phone_contact": "",
+    "mail_contact": "support@hook0.com",
+    "coordinate_list": [46.6824, -1.0628]
+  },
+  "subsidiary_location_list": [],
+  "website_url": "https://www.hook0.com",
+  "founded_year": 2021,
+  "kpi_list": [],
+  "solution_list": [
+    {
+      "title": "Hook0",
+      "logo_url": "https://www.hook0.com/mediakit/logo/110x110-white.png",
+      "website_url": "https://www.hook0.com",
+      "created_year": 2021,
+      "description": "Open-source webhooks-as-a-service (WaaS) platform. Allows SaaS companies to provide webhooks to their users via a simple API, handling delivery, HMAC signatures, automatic retries, monitoring, and subscriber management. Available as a managed cloud service or self-hosted.",
+      "category_list": ["Developer API"],
+      "similar_solution_list": [
+        {
+          "title": "Svix",
+          "similar_solution_url": "https://www.svix.com",
+          "category": "Developer API"
+        },
+        {
+          "title": "Convoy",
+          "similar_solution_url": "https://getconvoy.io",
+          "category": "Developer API"
+        },
+        {
+          "title": "Hookdeck",
+          "similar_solution_url": "https://hookdeck.com",
+          "category": "Developer API"
+        }
+      ],
+      "licence_list": ["sspl-1.0"],
+      "source_code_download": "https://github.com/hook0/hook0",
+      "source_code_profile": "https://www.openhub.net/p/hook0/analyses/latest/languages_summary",
+      "commercial_support_url": "https://www.hook0.com",
+      "floss_software": true,
+      "commercial_support_open_source_version": true,
+      "commercial_support_available": true,
+      "wikipedia_url": "",
+      "reference_list": [
+        {
+          "title": "Coinbase",
+          "country": "US",
+          "industry": "Banking and Finance"
+        },
+        {
+          "title": "WoodWing",
+          "country": "NL",
+          "industry": "Information Technology"
+        },
+        {
+          "title": "Optery",
+          "country": "US",
+          "industry": "Information Technology"
+        },
+        {
+          "title": "Alteos",
+          "country": "DE",
+          "industry": "Insurance"
+        },
+        {
+          "title": "ActiveAnts",
+          "country": "NL",
+          "industry": "Transport"
+        },
+        {
+          "title": "Apizee",
+          "country": "FR",
+          "industry": "Telecommunication"
+        }
+      ],
+      "success_case_list": []
+    }
+  ]
+}


### PR DESCRIPTION
Add **Hook0** (`hook0.json`), a French open-source Webhooks-as-a-Service platform based in Chantonnay, France.

- Open-source (SSPL-1.0), managed cloud or self-hosted
- Source code: https://github.com/hook0/hook0
- OpenHub: https://www.openhub.net/p/hook0

**6 references**: Coinbase, WoodWing, Optery, Alteos, ActiveAnts, Apizee

Validated against `JSON-schema.json` via `validator.py`.